### PR TITLE
chore: add turborrepo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "enabled": true,
+    "store": {
+      "kind": "filesystem",
+      "path": ".turbo"
+    }
+  },
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        "dist/**",
+        "build/**",
+        ".next/**"
+      ]
+    },
+    "dev": {
+      "cache": false
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "outputs": ["coverage/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `turbo.json` configuration with build, dev, lint, and test pipelines
- enable filesystem-backed remote cache for faster CI

## Testing
- `pnpm lint` *(fails: turbo: not found)*
- `pnpm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e369c5008321810c608397f209c3